### PR TITLE
feat: deprecate with_capacity and introduce with_per_node_capacity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "kiddo"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "aligned",
  "criterion",

--- a/benches/add_points.rs
+++ b/benches/add_points.rs
@@ -28,7 +28,7 @@ pub fn add_100_2d(c: &mut Criterion) {
                 (0..100).into_iter().map(|_| rand_data_2d()).collect();
 
             let mut points = vec![];
-            let mut kdtree = KdTree::with_capacity(16).unwrap();
+            let mut kdtree = KdTree::with_per_node_capacity(16).unwrap();
             for _ in 0..size {
                 points.push(rand_data_2d());
             }
@@ -55,7 +55,7 @@ pub fn add_100_3d(c: &mut Criterion) {
                 (0..100).into_iter().map(|_| rand_data_3d()).collect();
 
             let mut points = vec![];
-            let mut kdtree = KdTree::with_capacity(16).unwrap();
+            let mut kdtree = KdTree::with_per_node_capacity(16).unwrap();
             for _ in 0..size {
                 points.push(rand_data_3d());
             }
@@ -82,7 +82,7 @@ pub fn add_100_4d(c: &mut Criterion) {
                 (0..100).into_iter().map(|_| rand_data_4d()).collect();
 
             let mut points = vec![];
-            let mut kdtree = KdTree::with_capacity(16).unwrap();
+            let mut kdtree = KdTree::with_per_node_capacity(16).unwrap();
             for _ in 0..size {
                 points.push(rand_data_4d());
             }
@@ -109,7 +109,7 @@ pub fn add_100_3d_f32(c: &mut Criterion) {
                 (0..100).into_iter().map(|_| rand_data_3d_f32()).collect();
 
             let mut points = vec![];
-            let mut kdtree = KdTree::with_capacity(16).unwrap();
+            let mut kdtree = KdTree::with_per_node_capacity(16).unwrap();
             for _ in 0..size {
                 points.push(rand_data_3d_f32());
             }

--- a/benches/best_within_3d_unit_sphere.rs
+++ b/benches/best_within_3d_unit_sphere.rs
@@ -68,7 +68,7 @@ pub fn best_1_within_small_euclidean2(c: &mut Criterion) {
             let point = rand_sphere_data();
 
             let mut points = vec![];
-            let mut kdtree = KdTree::with_capacity(16).unwrap();
+            let mut kdtree = KdTree::with_per_node_capacity(16).unwrap();
             for _ in 0..size {
                 points.push(rand_sphere_data());
             }
@@ -96,7 +96,7 @@ pub fn best_1_within_medium_euclidean2(c: &mut Criterion) {
             let point = rand_sphere_data();
 
             let mut points = vec![];
-            let mut kdtree = KdTree::with_capacity(16).unwrap();
+            let mut kdtree = KdTree::with_per_node_capacity(16).unwrap();
             for _ in 0..size {
                 points.push(rand_sphere_data());
             }
@@ -124,7 +124,7 @@ pub fn best_1_within_large_euclidean2(c: &mut Criterion) {
             let point = rand_sphere_data();
 
             let mut points = vec![];
-            let mut kdtree = KdTree::with_capacity(16).unwrap();
+            let mut kdtree = KdTree::with_per_node_capacity(16).unwrap();
             for _ in 0..size {
                 points.push(rand_sphere_data());
             }
@@ -152,7 +152,7 @@ pub fn best_100_within_small_euclidean2(c: &mut Criterion) {
             let point = rand_sphere_data();
 
             let mut points = vec![];
-            let mut kdtree = KdTree::with_capacity(16).unwrap();
+            let mut kdtree = KdTree::with_per_node_capacity(16).unwrap();
             for _ in 0..size {
                 points.push(rand_sphere_data());
             }
@@ -180,7 +180,7 @@ pub fn best_100_within_medium_euclidean2(c: &mut Criterion) {
             let point = rand_sphere_data();
 
             let mut points = vec![];
-            let mut kdtree = KdTree::with_capacity(16).unwrap();
+            let mut kdtree = KdTree::with_per_node_capacity(16).unwrap();
             for _ in 0..size {
                 points.push(rand_sphere_data());
             }
@@ -208,7 +208,7 @@ pub fn best_100_within_large_euclidean2(c: &mut Criterion) {
             let point = rand_sphere_data();
 
             let mut points = vec![];
-            let mut kdtree = KdTree::with_capacity(16).unwrap();
+            let mut kdtree = KdTree::with_per_node_capacity(16).unwrap();
             for _ in 0..size {
                 points.push(rand_sphere_data());
             }

--- a/benches/nearest_3d_unit_sphere.rs
+++ b/benches/nearest_3d_unit_sphere.rs
@@ -68,7 +68,7 @@ pub fn nearest_1_euclidean2(c: &mut Criterion) {
             let point = rand_sphere_data();
 
             let mut points = vec![];
-            let mut kdtree = KdTree::with_capacity(16).unwrap();
+            let mut kdtree = KdTree::with_per_node_capacity(16).unwrap();
             for _ in 0..size {
                 points.push(rand_sphere_data());
             }
@@ -90,7 +90,7 @@ pub fn nearest_100_euclidean2(c: &mut Criterion) {
             let point = rand_sphere_data();
 
             let mut points = vec![];
-            let mut kdtree = KdTree::with_capacity(16).unwrap();
+            let mut kdtree = KdTree::with_per_node_capacity(16).unwrap();
             for _ in 0..size {
                 points.push(rand_sphere_data());
             }
@@ -112,7 +112,7 @@ pub fn nearest_1000_euclidean2(c: &mut Criterion) {
             let point = rand_sphere_data();
 
             let mut points = vec![];
-            let mut kdtree = KdTree::with_capacity(16).unwrap();
+            let mut kdtree = KdTree::with_per_node_capacity(16).unwrap();
             for _ in 0..size {
                 points.push(rand_sphere_data());
             }

--- a/benches/within_3d_unit_sphere.rs
+++ b/benches/within_3d_unit_sphere.rs
@@ -68,7 +68,7 @@ pub fn within_small_euclidean2(c: &mut Criterion) {
             let point = rand_sphere_data();
 
             let mut points = vec![];
-            let mut kdtree = KdTree::with_capacity(16).unwrap();
+            let mut kdtree = KdTree::with_per_node_capacity(16).unwrap();
             for _ in 0..size {
                 points.push(rand_sphere_data());
             }
@@ -90,7 +90,7 @@ pub fn within_medium_euclidean2(c: &mut Criterion) {
             let point = rand_sphere_data();
 
             let mut points = vec![];
-            let mut kdtree = KdTree::with_capacity(16).unwrap();
+            let mut kdtree = KdTree::with_per_node_capacity(16).unwrap();
             for _ in 0..size {
                 points.push(rand_sphere_data());
             }
@@ -112,7 +112,7 @@ pub fn within_large_euclidean2(c: &mut Criterion) {
             let point = rand_sphere_data();
 
             let mut points = vec![];
-            let mut kdtree = KdTree::with_capacity(16).unwrap();
+            let mut kdtree = KdTree::with_per_node_capacity(16).unwrap();
             for _ in 0..size {
                 points.push(rand_sphere_data());
             }
@@ -134,7 +134,7 @@ pub fn within_unsorted_small_euclidean2(c: &mut Criterion) {
             let point = rand_sphere_data();
 
             let mut points = vec![];
-            let mut kdtree = KdTree::with_capacity(16).unwrap();
+            let mut kdtree = KdTree::with_per_node_capacity(16).unwrap();
             for _ in 0..size {
                 points.push(rand_sphere_data());
             }
@@ -158,7 +158,7 @@ pub fn within_unsorted_medium_euclidean2(c: &mut Criterion) {
             let point = rand_sphere_data();
 
             let mut points = vec![];
-            let mut kdtree = KdTree::with_capacity(16).unwrap();
+            let mut kdtree = KdTree::with_per_node_capacity(16).unwrap();
             for _ in 0..size {
                 points.push(rand_sphere_data());
             }
@@ -182,7 +182,7 @@ pub fn within_unsorted_large_euclidean2(c: &mut Criterion) {
             let point = rand_sphere_data();
 
             let mut points = vec![];
-            let mut kdtree = KdTree::with_capacity(16).unwrap();
+            let mut kdtree = KdTree::with_per_node_capacity(16).unwrap();
             for _ in 0..size {
                 points.push(rand_sphere_data());
             }

--- a/src/kiddo.rs
+++ b/src/kiddo.rs
@@ -80,7 +80,7 @@ pub enum ErrorKind {
 }
 
 impl<A: Float + Zero + One, T: std::cmp::PartialEq, const K: usize> KdTree<A, T, K> {
-    /// Creates a new KdTree with default capacity per node of 16
+    /// Creates a new KdTree with default capacity **per node** of 16.
     ///
     /// # Examples
     ///
@@ -93,22 +93,24 @@ impl<A: Float + Zero + One, T: std::cmp::PartialEq, const K: usize> KdTree<A, T,
     /// # Ok::<(), kiddo::ErrorKind>(())
     /// ```
     pub fn new() -> Self {
-        KdTree::with_capacity(16).unwrap()
+        KdTree::with_per_node_capacity(16).unwrap()
     }
 
-    /// Creates a new KdTree with a specific capacity per node
+    /// Creates a new KdTree with a specific capacity **per node**. You may wish to
+    /// experiment by tuning this value to best suit your workload via benchmarking:
+    /// values between 10 and 40 often work best.
     ///
     /// # Examples
     ///
     /// ```rust
     /// use kiddo::KdTree;
     ///
-    /// let mut tree: KdTree<f64, usize, 3> = KdTree::with_capacity(8)?;
+    /// let mut tree: KdTree<f64, usize, 3> = KdTree::with_per_node_capacity(30)?;
     ///
     /// tree.add(&[1.0, 2.0, 5.0], 100)?;
     /// # Ok::<(), kiddo::ErrorKind>(())
     /// ```
-    pub fn with_capacity(capacity: usize) -> Result<Self, ErrorKind> {
+    pub fn with_per_node_capacity(capacity: usize) -> Result<Self, ErrorKind> {
         if capacity == 0 {
             return Err(ErrorKind::ZeroCapacity);
         }
@@ -123,6 +125,13 @@ impl<A: Float + Zero + One, T: std::cmp::PartialEq, const K: usize> KdTree<A, T,
                 capacity,
             },
         })
+    }
+
+    /// Creates a new KdTree with a specific capacity **per node**.
+    ///
+    #[deprecated(since = "0.1.8", note = "with_capacity has a misleading name. Users should instead use with_per_node_capacity. with_capacity will be removed in a future release")]
+    pub fn with_capacity(capacity: usize) -> Result<Self, ErrorKind> {
+        Self::with_per_node_capacity(capacity)
     }
 
     /// Returns the current number of elements stored in the tree
@@ -865,8 +874,8 @@ impl<A: Float + Zero + One, T: std::cmp::PartialEq, const K: usize> KdTree<A, T,
                     let max = self.max_bounds[split_dimension];
                     let split_value = min + (max - min) / A::from(2.0).unwrap();
 
-                    let mut left = Box::new(KdTree::with_capacity(*capacity).unwrap());
-                    let mut right = Box::new(KdTree::with_capacity(*capacity).unwrap());
+                    let mut left = Box::new(KdTree::with_per_node_capacity(*capacity).unwrap());
+                    let mut right = Box::new(KdTree::with_per_node_capacity(*capacity).unwrap());
 
                     while !points.is_empty() {
                         let point = points.swap_remove(0);

--- a/tests/count_dist.rs
+++ b/tests/count_dist.rs
@@ -12,7 +12,7 @@ static POINT_D: ([f64; 2], usize) = ([3f64, 3f64], 3);
 #[test]
 fn it_works() {
     let capacity_per_node = 2;
-    let mut kdtree = KdTree::with_capacity(capacity_per_node).unwrap();
+    let mut kdtree = KdTree::with_per_node_capacity(capacity_per_node).unwrap();
 
     let count = AtomicUsize::new(0);
     let new_dist = |a: &[f64; 2], b: &[f64; 2]| {

--- a/tests/kdtree.rs
+++ b/tests/kdtree.rs
@@ -12,7 +12,7 @@ static POINT_D: ([f64; 2], usize) = ([3f64, 3f64], 3);
 #[test]
 fn it_works() {
     let capacity_per_node = 2;
-    let mut kdtree = KdTree::with_capacity(capacity_per_node).unwrap();
+    let mut kdtree = KdTree::with_per_node_capacity(capacity_per_node).unwrap();
 
     kdtree.add(&POINT_A.0, POINT_A.1).unwrap();
     kdtree.add(&POINT_B.0, POINT_B.1).unwrap();
@@ -84,7 +84,7 @@ fn it_works() {
 fn handles_non_finite_coordinate() {
     let point_a = ([std::f64::NAN, std::f64::NAN], 0f64);
     let point_b = ([std::f64::INFINITY, std::f64::INFINITY], 0f64);
-    let mut kdtree = KdTree::with_capacity(1).unwrap();
+    let mut kdtree = KdTree::with_per_node_capacity(1).unwrap();
 
     assert_eq!(
         kdtree.add(&point_a.0, point_a.1),
@@ -106,7 +106,7 @@ fn handles_non_finite_coordinate() {
 
 #[test]
 fn handles_singularity() {
-    let mut kdtree = KdTree::with_capacity(1).unwrap();
+    let mut kdtree = KdTree::with_per_node_capacity(1).unwrap();
     kdtree.add(&POINT_A.0, POINT_A.1).unwrap();
     kdtree.add(&POINT_A.0, POINT_A.1).unwrap();
     kdtree.add(&POINT_A.0, POINT_A.1).unwrap();
@@ -128,7 +128,7 @@ fn handles_pending_order() {
 
     // Build a kd tree
     let capacity_per_node = 2;
-    let mut kdtree = KdTree::with_capacity(capacity_per_node).unwrap();
+    let mut kdtree = KdTree::with_per_node_capacity(capacity_per_node).unwrap();
 
     kdtree.add(&item1.0, item1.1).unwrap();
     kdtree.add(&item2.0, item2.1).unwrap();
@@ -219,7 +219,7 @@ fn handles_drops_correctly() {
     {
         // Build a kd tree
         let capacity_per_node = 1;
-        let mut kdtree = KdTree::with_capacity(capacity_per_node).unwrap();
+        let mut kdtree = KdTree::with_per_node_capacity(capacity_per_node).unwrap();
 
         kdtree.add(&item1.0, item1.1).unwrap();
         kdtree.add(&item2.0, item2.1).unwrap();
@@ -243,7 +243,7 @@ fn handles_remove_correctly() {
 
     // Build a kd tree
     let capacity_per_node = 2;
-    let mut kdtree = KdTree::with_capacity(capacity_per_node).unwrap();
+    let mut kdtree = KdTree::with_per_node_capacity(capacity_per_node).unwrap();
 
     kdtree.add(&item1.0, item1.1).unwrap();
     kdtree.add(&item2.0, item2.1).unwrap();
@@ -268,7 +268,7 @@ fn handles_remove_multiple_match() {
 
     // Build a kd tree
     let capacity_per_node = 2;
-    let mut kdtree = KdTree::with_capacity(capacity_per_node).unwrap();
+    let mut kdtree = KdTree::with_per_node_capacity(capacity_per_node).unwrap();
 
     kdtree.add(&item1.0, item1.1).unwrap();
     kdtree.add(&item2.0, item2.1).unwrap();
@@ -294,7 +294,7 @@ fn handles_remove_no_match() {
 
     // Build a kd tree
     let capacity_per_node = 2;
-    let mut kdtree = KdTree::with_capacity(capacity_per_node).unwrap();
+    let mut kdtree = KdTree::with_per_node_capacity(capacity_per_node).unwrap();
 
     kdtree.add(&item1.0, item1.1).unwrap();
     kdtree.add(&item2.0, item2.1).unwrap();

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -4,7 +4,6 @@ use serde_json;
 extern crate kiddo;
 
 use kiddo::distance::squared_euclidean;
-use kiddo::ErrorKind;
 use kiddo::KdTree;
 
 static POINT_A: ([f64; 2], usize) = ([0f64, 0f64], 0);
@@ -16,7 +15,7 @@ static POINT_D: ([f64; 2], usize) = ([3f64, 3f64], 3);
 #[test]
 fn it_serializes_and_deserializes_properly() {
     let capacity_per_node = 2;
-    let mut kdtree = KdTree::with_capacity(capacity_per_node).unwrap();
+    let mut kdtree = KdTree::with_per_node_capacity(capacity_per_node).unwrap();
 
     kdtree.add(&POINT_A.0, POINT_A.1).unwrap();
     kdtree.add(&POINT_B.0, POINT_B.1).unwrap();


### PR DESCRIPTION
Addresses point raised in https://github.com/sdd/kiddo/issues/10: `with_capacity` is potentially confusingly named.