### PR TITLE
fixed inifite loop in remove

### DIFF
--- a/src/kiddo.rs
+++ b/src/kiddo.rs
@@ -820,12 +820,15 @@ impl<A: Float + Zero + One, T: std::cmp::PartialEq, const K: usize> KdTree<A, T,
                 ref mut bucket,
                 ..
             } => {
-                while let Some(p_index) = points.iter().position(|x| x == point) {
-                    if &bucket[p_index] == data {
-                        points.remove(p_index);
-                        bucket.remove(p_index);
+                let mut p_index = 0;
+                while p_index < self.size {
+                    if &points[p_index] == point && &bucket[p_index] == data {
+                        points.swap_remove(p_index);
+                        bucket.swap_remove(p_index);
                         removed += 1;
                         self.size -= 1;
+                    } else {
+                        p_index += 1;
                     }
                 }
             }

--- a/tests/kdtree.rs
+++ b/tests/kdtree.rs
@@ -240,6 +240,7 @@ fn handles_remove_correctly() {
     let item2 = ([100f64], 2);
     let item3 = ([45f64], 3);
     let item4 = ([55f64], 4);
+    let item5 = ([45f64], 5);
 
     // Build a kd tree
     let capacity_per_node = 2;
@@ -249,13 +250,14 @@ fn handles_remove_correctly() {
     kdtree.add(&item2.0, item2.1).unwrap();
     kdtree.add(&item3.0, item3.1).unwrap();
     kdtree.add(&item4.0, item4.1).unwrap();
+    kdtree.add(&item5.0, item5.1).unwrap();
 
     let num_removed = kdtree.remove(&&item3.0, &item3.1).unwrap();
-    assert_eq!(kdtree.size(), 3);
+    assert_eq!(kdtree.size(), 4);
     assert_eq!(num_removed, 1);
     assert_eq!(
-        kdtree.nearest(&[51f64], 2, &squared_euclidean).unwrap(),
-        vec![(16.0, &4), (2401.0, &2)]
+        kdtree.nearest(&[51f64], 3, &squared_euclidean).unwrap(),
+        vec![(16.0, &4), (36.0, &5), (2401.0, &2)]
     );
 }
 


### PR DESCRIPTION
Fixed a bug where remove will get stuck in an infinite loop, when removing a point with multiple non equal data entries.