### PR TITLE
fixed stack overflow when displaying error messages

### DIFF
--- a/src/kiddo.rs
+++ b/src/kiddo.rs
@@ -1005,19 +1005,16 @@ where
     }
 }
 
-impl std::error::Error for ErrorKind {
-    fn description(&self) -> &str {
-        match *self {
-            ErrorKind::NonFiniteCoordinate => "non-finite coordinate",
-            ErrorKind::ZeroCapacity => "zero capacity",
-            ErrorKind::Empty => "invalid operation on empty tree",
-        }
-    }
-}
+impl std::error::Error for ErrorKind {}
 
 impl std::fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "KdTree error: {}", self)
+        let reason = match *self {
+            ErrorKind::NonFiniteCoordinate => "non-finite coordinate",
+            ErrorKind::ZeroCapacity => "zero capacity",
+            ErrorKind::Empty => "invalid operation on empty tree",
+        };
+        write!(f, "KdTree error: {}", reason)
     }
 }
 

--- a/tests/kdtree.rs
+++ b/tests/kdtree.rs
@@ -311,3 +311,10 @@ fn handles_remove_no_match() {
         vec![(16.0, &4), (36.0, &3)]
     );
 }
+
+#[test]
+fn error_messages_do_not_overflow_stack() {
+    format!("{}", ErrorKind::NonFiniteCoordinate);
+    format!("{}", ErrorKind::ZeroCapacity);
+    format!("{}", ErrorKind::Empty);
+}


### PR DESCRIPTION
Fixes a bug where a stack overflow is created when trying to display the `kiddo::ErrorKind`