### PR TITLE
added working implementation of periodic boundary conditions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = "1.0.64"
 
 [dependencies]
 num-traits = "0.2"
+itertools = "0.10.3"
 
 [dependencies.serde]
 version = "1.0"

--- a/src/distance.rs
+++ b/src/distance.rs
@@ -3,6 +3,7 @@
 //! squares of the distances in each dimension.
 
 use num_traits::Float;
+use itertools::{iproduct, Itertools, MinMaxResult};
 
 #[cfg(any(target_arch = "x86_64"))]
 use std::arch::x86_64::*;
@@ -12,6 +13,7 @@ union SimdToArray {
     array: [f32; 4],
     simd: __m128,
 }
+
 
 /// Returns the squared euclidean distance between two points. When you only
 /// need to compare distances, rather than having the exact distance between
@@ -32,6 +34,50 @@ pub fn squared_euclidean<T: Float, const K: usize>(a: &[T; K], b: &[T; K]) -> T 
         .zip(b.iter())
         .map(|(x, y)| ((*x) - (*y)) * ((*x) - (*y)))
         .fold(T::zero(), ::std::ops::Add::add)
+}
+
+pub fn periodic_distance<T: Float, const K: usize>(
+    a: &[T; K],
+    b: &[T; K],
+    boxsize: Option<[T; K]>,
+    distance: &dyn Fn(&[T; K], &[T; K]) -> T,
+) -> T {
+
+    
+    // Gather 3^K distances and choose minimum
+    let mut ds : Vec<T> = Vec::with_capacity(3_usize.pow(K as u32));
+
+    // 3^K copies (incl original)
+    use std::convert::TryInto;
+    let copies : Vec<Vec<T>> = n_product::<T, K>().expect("error making copies");
+    for copy in copies {
+        let new_p1 = a.to_vec().iter().enumerate().map(|(i, &x)| x + copy[i]*boxsize.unwrap()[i]).collect::<Vec<T>>();
+        ds.push(distance(&new_p1.try_into().unwrap_or_else(|v: Vec<T>| panic!("Expected a Vec of length {} but it was {}", K, v.len())), &b))
+    }
+
+    debug_assert_eq!(ds.len(), 3_usize.pow(K as u32));
+   // return min, discard max
+    *match ds.iter().minmax(){
+        MinMaxResult::MinMax(min, _max) => Ok(min),
+        _ => Err("No Min"), 
+    }.unwrap()
+
+}
+
+// Used for periodic distance calculation
+fn n_product<T: Float, const K: usize> () -> Result<Vec<Vec<T>>, String> {
+
+    let m : [T; 3] = [-T::one(), T::zero(), T::one()];
+
+    match K {
+        1 => Ok(iproduct!(m).map(|a| vec![a]).collect::<Vec<Vec<T>>>()),
+        2 => Ok(iproduct!(m, m).map(|(a, b)| vec![a, b]).collect::<Vec<Vec<T>>>()),
+        3 => Ok(iproduct!(m, m, m).map(|(a, b, c)| vec![a, b, c]).collect::<Vec<Vec<T>>>()),
+        4 => Ok(iproduct!(m, m, m, m).map(|(a, b, c, d)| vec![a, b, c, d]).collect::<Vec<Vec<T>>>()),
+        5 => Ok(iproduct!(m, m, m, m, m).map(|(a, b, c, d, e)| vec![a, b, c, d, e]).collect::<Vec<Vec<T>>>()),
+        6 => Ok(iproduct!(m, m, m, m, m, m).map(|(a, b, c, d, e, f)| vec![a, b, c, d, e, f]).collect::<Vec<Vec<T>>>()),
+        _ => Err("Dimensions not in 1..=6 not implemented".to_string())
+    }
 }
 
 pub fn dot_product<const K: usize>(a: &[f32; K], b: &[f32; K]) -> f32 {

--- a/tests/kdtree.rs
+++ b/tests/kdtree.rs
@@ -1,13 +1,27 @@
 extern crate kiddo;
 
 use kiddo::distance::squared_euclidean;
+use kiddo::distance::periodic_distance;
 use kiddo::ErrorKind;
 use kiddo::KdTree;
+
 
 static POINT_A: ([f64; 2], usize) = ([0f64, 0f64], 0);
 static POINT_B: ([f64; 2], usize) = ([1f64, 1f64], 1);
 static POINT_C: ([f64; 2], usize) = ([2f64, 2f64], 2);
 static POINT_D: ([f64; 2], usize) = ([3f64, 3f64], 3);
+
+static PERIODIC_2DPOINT_A: ([f64; 2], usize) = ([1.0, 5.0], 0);
+static PERIODIC_2DPOINT_B: ([f64; 2], usize) = ([9.0, 5.0], 1);
+static PERIODIC_2DPOINT_C: ([f64; 2], usize) = ([5.0, 1.0], 2);
+static PERIODIC_2DPOINT_D: ([f64; 2], usize) = ([5.0, 9.0], 3);
+
+static F64_BOXSIZE_1D: [f64; 1] = [10.0];
+static F64_BOXSIZE_2D: [f64; 2] = [10.0, 10.0];
+static F64_BOXSIZE_3D: [f64; 3] = [10.0, 10.0, 10.0];
+static F32_BOXSIZE_3D: [f32; 3] = [10.0, 10.0, 10.0];
+static F64_TOLERANCE : f64 = 1e-6;
+static F32_TOLERANCE : f32 = 1e-6;
 
 #[test]
 fn it_works() {
@@ -317,4 +331,280 @@ fn error_messages_do_not_overflow_stack() {
     format!("{}", ErrorKind::NonFiniteCoordinate);
     format!("{}", ErrorKind::ZeroCapacity);
     format!("{}", ErrorKind::Empty);
+}
+
+
+#[test]
+fn test_periodic_squared_euclidean_1d_f64(){
+
+    // Define two points that are 2.0 units away (wrapped)
+    let p1 : &[f64; 1] = &[1.0];
+    let p2 : &[f64; 1] = &[9.0];
+
+    let result = periodic_distance(p1, p2, Some(F64_BOXSIZE_1D), &squared_euclidean);
+    let expected = 2.0 * 2.0;
+
+    assert!((result-expected).abs() < F64_TOLERANCE);
+}
+
+#[test]
+fn test_periodic_squared_euclidean_leftright_2d_f64(){
+
+    // Define two points that are 2.0 units away (wrapped)
+    let p1 : &[f64; 2] = &[1.0, 5.0];
+    let p2 : &[f64; 2] = &[9.0, 5.0];
+
+    let result = periodic_distance(p1, p2, Some(F64_BOXSIZE_2D), &squared_euclidean);
+    let expected = 2.0 * 2.0;
+
+    assert!((result-expected).abs() < F64_TOLERANCE);
+}
+
+#[test]
+fn test_periodic_squared_euclidean_topbottom_2d_f64(){
+
+    // Define two points that are 2.0 units away (wrapped)
+    let p1 : &[f64; 2] = &[5.0, 1.0];
+    let p2 : &[f64; 2] = &[5.0, 9.0];
+
+    let result = periodic_distance(p1, p2, Some(F64_BOXSIZE_2D), &squared_euclidean);
+    let expected = 2.0 * 2.0;
+
+    assert!((result-expected).abs() < F64_TOLERANCE);
+}
+
+
+#[test]
+fn test_periodic_squared_euclidean_frontback_3d_f64(){
+
+    // x-axis
+    // Define two points that are 2.0 units away (wrapped)
+    let p1 : &[f64; 3] = &[1.0, 5.0, 5.0];
+    let p2 : &[f64; 3] = &[9.0, 5.0, 5.0];
+
+    let result = periodic_distance(p1, p2, Some(F64_BOXSIZE_3D), &squared_euclidean);
+    let expected = 2.0 * 2.0;
+
+    assert!((result-expected).abs() < F64_TOLERANCE);
+}
+
+#[test]
+fn test_periodic_squared_euclidean_leftright_3d_f64(){
+
+    // y-axis
+    // Define two points that are 2.0 units away (wrapped)
+    let p1 : &[f64; 3] = &[5.0, 1.0, 5.0];
+    let p2 : &[f64; 3] = &[5.0, 9.0, 5.0];
+
+    let result = periodic_distance(p1, p2, Some(F64_BOXSIZE_3D), &squared_euclidean);
+    let expected = 2.0 * 2.0;
+
+    assert!((result-expected).abs() < F64_TOLERANCE);
+}
+
+#[test]
+fn test_periodic_squared_euclidean_topbottom_3d_f64(){
+
+    // z-axis
+    // Define two points that are 2.0 units away (wrapped)
+    let p1 : &[f64; 3] = &[5.0, 5.0, 1.0];
+    let p2 : &[f64; 3] = &[5.0, 5.0, 9.0];
+
+    let result = periodic_distance(p1, p2, Some(F64_BOXSIZE_3D), &squared_euclidean);
+    let expected = 2.0 * 2.0;
+
+    assert!((result-expected).abs() < F64_TOLERANCE);
+}
+
+#[test]
+fn test_periodic_squared_euclidean_within_frontback_3d_f64(){
+
+    // x-axis
+    // Define two points that are 2.0 units away (not wrapped)
+    let p1 : &[f64; 3] = &[4.0, 5.0, 5.0];
+    let p2 : &[f64; 3] = &[6.0, 5.0, 5.0];
+
+    let result = periodic_distance(p1, p2, Some(F64_BOXSIZE_3D), &squared_euclidean);
+    let expected = 2.0 * 2.0;
+
+    assert!((result-expected).abs() < F64_TOLERANCE);
+}
+#[test]
+fn test_periodic_squared_euclidean_within_leftright_3d_f64(){
+
+    // y-axis
+    // Define two points that are 2.0 units away (not wrapped)
+    let p1 : &[f64; 3] = &[5.0, 4.0, 5.0];
+    let p2 : &[f64; 3] = &[5.0, 6.0, 5.0];
+
+    let result = periodic_distance(p1, p2, Some(F64_BOXSIZE_3D), &squared_euclidean);
+    let expected = 2.0 * 2.0;
+
+    assert!((result-expected).abs() < F64_TOLERANCE);
+}
+#[test]
+fn test_periodic_squared_euclidean_within_topbottom_3d_f64(){
+
+    // z-axis
+    // Define two points that are 2.0 units away (not wrapped)
+    let p1 : &[f64; 3] = &[5.0, 5.0, 4.0];
+    let p2 : &[f64; 3] = &[5.0, 5.0, 6.0];
+
+    let result = periodic_distance(p1, p2, Some(F64_BOXSIZE_3D), &squared_euclidean);
+    let expected = 2.0 * 2.0;
+
+    assert!((result-expected).abs() < F64_TOLERANCE);
+}
+
+#[test]
+fn test_periodic_squared_euclidean_frontback_3d_f32(){
+
+    // x-axis
+    // Define two points that are 2.0 units away (wrapped)
+    let p1 : &[f32; 3] = &[1.0, 5.0, 5.0];
+    let p2 : &[f32; 3] = &[9.0, 5.0, 5.0];
+
+    let result = periodic_distance(p1, p2, Some(F32_BOXSIZE_3D), &squared_euclidean);
+    let expected = 2.0 * 2.0;
+
+    assert!((result-expected).abs() < F32_TOLERANCE);
+}
+
+#[test]
+fn test_periodic_squared_euclidean_leftright_3d_f32(){
+
+    // y-axis
+    // Define two points that are 2.0 units away (wrapped)
+    let p1 : &[f32; 3] = &[5.0, 1.0, 5.0];
+    let p2 : &[f32; 3] = &[5.0, 9.0, 5.0];
+
+    let result = periodic_distance(p1, p2, Some(F32_BOXSIZE_3D), &squared_euclidean);
+    let expected = 2.0 * 2.0;
+
+    assert!((result-expected).abs() < F32_TOLERANCE);
+}
+
+#[test]
+fn test_periodic_squared_euclidean_topbottom_3d_f32(){
+
+    // z-axis
+    // Define two points that are 2.0 units away (wrapped)
+    let p1 : &[f32; 3] = &[5.0, 5.0, 1.0];
+    let p2 : &[f32; 3] = &[5.0, 5.0, 9.0];
+
+    let result = periodic_distance(p1, p2, Some(F32_BOXSIZE_3D), &squared_euclidean);
+    let expected = 2.0 * 2.0;
+
+    assert!((result-expected).abs() < F32_TOLERANCE);
+}
+
+#[test]
+fn test_periodic_squared_euclidean_within_frontback_3d_f32(){
+
+    // x-axis
+    // Define two points that are 2.0 units away (not wrapped)
+    let p1 : &[f32; 3] = &[4.0, 5.0, 5.0];
+    let p2 : &[f32; 3] = &[6.0, 5.0, 5.0];
+
+    let result = periodic_distance(p1, p2, Some(F32_BOXSIZE_3D), &squared_euclidean);
+    let expected = 2.0 * 2.0;
+
+    assert!((result-expected).abs() < F32_TOLERANCE);
+}
+#[test]
+fn test_periodic_squared_euclidean_within_leftright_3d_f32(){
+
+    // y-axis
+    // Define two points that are 2.0 units away (not wrapped)
+    let p1 : &[f32; 3] = &[5.0, 4.0, 5.0];
+    let p2 : &[f32; 3] = &[5.0, 6.0, 5.0];
+
+    let result = periodic_distance(p1, p2, Some(F32_BOXSIZE_3D), &squared_euclidean);
+    let expected = 2.0 * 2.0;
+
+    assert!((result-expected).abs() < F32_TOLERANCE);
+}
+
+#[test]
+fn test_periodic_squared_euclidean_within_topbottom_3d_f32(){
+
+    // z-axis
+    // Define two points that are 2.0 units away (not wrapped)
+    let p1 : &[f32; 3] = &[5.0, 5.0, 4.0];
+    let p2 : &[f32; 3] = &[5.0, 5.0, 6.0];
+
+    let result = periodic_distance(p1, p2, Some(F32_BOXSIZE_3D), &squared_euclidean);
+    let expected = 2.0 * 2.0;
+
+    assert!((result-expected).abs() < F32_TOLERANCE);
+}
+#[test]
+fn test_periodic_kdtree_2d() {
+    let capacity_per_node = 2;
+    let mut kdtree = KdTree::periodic_with_per_node_capacity(capacity_per_node, F64_BOXSIZE_2D).unwrap();
+
+    kdtree.add(&PERIODIC_2DPOINT_A.0, PERIODIC_2DPOINT_A.1).unwrap();
+    kdtree.add(&PERIODIC_2DPOINT_B.0, PERIODIC_2DPOINT_B.1).unwrap();
+    kdtree.add(&PERIODIC_2DPOINT_C.0, PERIODIC_2DPOINT_C.1).unwrap();
+    kdtree.add(&PERIODIC_2DPOINT_D.0, PERIODIC_2DPOINT_D.1).unwrap();
+
+    assert_eq!(kdtree.size(), 4);
+    assert_eq!(
+        kdtree.nearest(&PERIODIC_2DPOINT_A.0, 0, &squared_euclidean).unwrap(),
+        vec![]
+    );
+    assert_eq!(
+        kdtree.nearest(&PERIODIC_2DPOINT_A.0, 1, &squared_euclidean).unwrap(),
+        vec![(0f64, &0)]
+    );
+    assert_eq!(
+        kdtree.nearest(&PERIODIC_2DPOINT_A.0, 2, &squared_euclidean).unwrap(),
+        vec![(0f64, &0), (4f64, &1)]
+    );
+    assert_eq!(
+        kdtree.nearest(&PERIODIC_2DPOINT_A.0, 3, &squared_euclidean).unwrap(),
+        vec![(0f64, &0), (4f64, &1), (32f64, &3)]
+    );
+    assert_eq!(
+        kdtree.nearest(&PERIODIC_2DPOINT_A.0, 4, &squared_euclidean).unwrap(),
+        vec![(0f64, &0), (4f64, &1), (32f64, &2), (32f64, &3)]
+    );
+    assert_eq!(
+        kdtree.nearest(&PERIODIC_2DPOINT_A.0, 5, &squared_euclidean).unwrap(),
+        vec![(0f64, &0), (4f64, &1), (32f64, &2), (32f64, &3)]
+    );
+    assert_eq!(
+        kdtree.nearest(&PERIODIC_2DPOINT_B.0, 4, &squared_euclidean).unwrap(),
+        vec![(0f64, &1), (4f64, &0), (32f64, &2), (32f64, &3)]
+    );
+
+    assert_eq!(
+        kdtree.nearest_one(&PERIODIC_2DPOINT_A.0, &squared_euclidean).unwrap(),
+        (0f64, &0)
+    );
+    assert_eq!(
+        kdtree.nearest_one(&PERIODIC_2DPOINT_B.0, &squared_euclidean).unwrap(),
+        (0f64, &1)
+    );
+
+    assert_eq!(
+        kdtree.within(&PERIODIC_2DPOINT_A.0, 0.0, &squared_euclidean).unwrap(),
+        vec![(0.0, &0)]
+    );
+    assert_eq!(
+        kdtree.within(&PERIODIC_2DPOINT_B.0, 1.0, &squared_euclidean).unwrap(),
+        vec![(0.0, &1)]
+    );
+    assert_eq!(
+        kdtree.within(&PERIODIC_2DPOINT_B.0, 32.0, &squared_euclidean).unwrap(),
+        vec![(0.0, &1), (32.0, &2), (32.0, &3)]
+    );
+
+    assert_eq!(
+        kdtree
+            .iter_nearest(&PERIODIC_2DPOINT_A.0, &squared_euclidean)
+            .unwrap()
+            .collect::<Vec<_>>(),
+        vec![(0f64, &0), (32f64, &3), (32f64, &2), (64f64, &1)]
+    );
 }


### PR DESCRIPTION
Minimum viable product with extensive testing suite; backwards compatible.

The implementation adds a `boxsize : Option<[A; K]>` to some of the structs, which changes nothing about the previous implementation if `None`. 

If `Some(...)` then a few things change:
1) it changes the distance metric to be the minimum of the distance of a point to all 3^K copies of the other point displaced by the size of the specified box size. To give an example in two dimensions, consider the point (1, 5) and (9,5) with a box size of (10, 10). Here, the distance between (9,5) and every point in the set { (1,5), (-9, 5), (-9, -5), (-9, 15), (1, -5), (1, 15), (11, -5), (11, 5), (11, 15) } is computed. The smallest distance is the one between (9,5) and (11,5).

2) `min_bounds` is set to be at the origin, and `max_bounds` is set to be the value in `boxsize`.



This is a minimum viable product, and there are instances where some unintended behavior can occur. Off of the top of my head, 

1) currently, neither the added points nor any query points are enforced to be between `min_bounds` and `max_bounds`.

--> as such the distance_to_space will return nonzero values despite the periodicity ensuring the points span R^N.

--> a point provided outside of the bounds will not be brought back within the space and the distance computed may not be the desired one (although... why are you providing query points out of the space?)

I will get to these later, but wanted to put out a minimum viable product.