### PR TITLE
A better PBC implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ criterion = "0.3.4"
 aligned = "0.4"
 serde = "1.0"
 serde_json = "1.0.64"
+rayon = "1.5.3"
 
 [dependencies]
 num-traits = "0.2"

--- a/src/kiddo.rs
+++ b/src/kiddo.rs
@@ -151,14 +151,15 @@ impl<'a, A: Float + Zero + One + Signed, T: std::cmp::PartialEq, const K: usize>
 
     /// Creates a new KdTree with a specific capacity **per node**. You may wish to
     /// experiment by tuning this value to best suit your workload via benchmarking:
-    /// values between 10 and 40 often work best.
+    /// values between 10 and 40 often work best. Obeys periodic boundary conditions.
     ///
     /// # Examples
     ///
     /// ```rust
     /// use kiddo::KdTree;
     ///
-    /// let mut tree: KdTree<f64, usize, 3> = KdTree::with_per_node_capacity(30)?;
+    /// const PERIODIC: [f64; 3] = [10.0, 10.0, 10.0];
+    /// let mut tree: KdTree<f64, usize, 3> = KdTree::periodic_with_per_node_capacity(30, &PERIODIC)?;
     ///
     /// tree.add(&[1.0, 2.0, 5.0], 100)?;
     /// # Ok::<(), kiddo::ErrorKind>(())

--- a/src/kiddo.rs
+++ b/src/kiddo.rs
@@ -1608,7 +1608,7 @@ impl std::error::Error for ErrorKind {}
 impl std::fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let reason = match *self {
-            ErrorKind::OutOfPeriodicBounds => "out of bounds while using periodic boundary conditions",
+            ErrorKind::OutOfPeriodicBounds => "point is out of bounds (periodic boundary conditions)",
             ErrorKind::NonFiniteCoordinate => "non-finite coordinate",
             ErrorKind::ZeroCapacity => "zero capacity",
             ErrorKind::Empty => "invalid operation on empty tree",

--- a/src/kiddo.rs
+++ b/src/kiddo.rs
@@ -127,6 +127,56 @@ impl<'a, A: Float + Zero + One + Signed, T: std::cmp::PartialEq, const K: usize>
                 bucket: Vec::with_capacity(capacity),
                 capacity,
             },
+            periodic: None,
+        })
+    }
+
+    /// Creates a new KdTree with default capacity **per node** of 16.
+    /// Obeys periodic boundary conditions.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use kiddo::KdTree;
+    ///
+    /// let mut tree: KdTree<f64, usize, 3> = KdTree::new();
+    ///
+    /// tree.add(&[1.0, 2.0, 5.0], 100)?;
+    /// # Ok::<(), kiddo::ErrorKind>(())
+    /// ```
+    pub fn new_periodic(periodic: &'a [A; K]) -> Self {
+        KdTree::periodic_with_per_node_capacity(16, periodic).unwrap()
+    }
+
+    /// Creates a new KdTree with a specific capacity **per node**. You may wish to
+    /// experiment by tuning this value to best suit your workload via benchmarking:
+    /// values between 10 and 40 often work best.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use kiddo::KdTree;
+    ///
+    /// let mut tree: KdTree<f64, usize, 3> = KdTree::with_per_node_capacity(30)?;
+    ///
+    /// tree.add(&[1.0, 2.0, 5.0], 100)?;
+    /// # Ok::<(), kiddo::ErrorKind>(())
+    /// ```
+    pub fn periodic_with_per_node_capacity(capacity: usize, periodic: &'a [A; K]) -> Result<Self, ErrorKind> {
+        if capacity == 0 {
+            return Err(ErrorKind::ZeroCapacity);
+        }
+
+        Ok(KdTree {
+            size: 0,
+            min_bounds: [A::infinity(); K],
+            max_bounds: [A::neg_infinity(); K],
+            content: Node::Leaf {
+                points: Vec::with_capacity(capacity),
+                bucket: Vec::with_capacity(capacity),
+                capacity,
+            },
+            periodic: Some(periodic),
         })
     }
 

--- a/tests/kdtree.rs
+++ b/tests/kdtree.rs
@@ -409,7 +409,7 @@ fn test_periodic_1d_nearest() {
     let mut rng = rand::thread_rng();
 
     // Initialize KdTree
-    let mut tree = KdTree::with_per_node_capacity(32).unwrap();
+    let mut tree = KdTree::periodic_with_per_node_capacity(32, &PERIODIC).unwrap();
 
     // Initialize data points (aka point cloud)
     let mut data = vec![[0.0; K]; NDATA];
@@ -436,8 +436,8 @@ fn test_periodic_1d_nearest() {
     // Query points
     let knns: Vec<(f64, &usize)> = (&query)
         .into_par_iter()
-        .map_with((&tree, &PERIODIC), |(t, p), q| {
-            t.nearest_one_periodic(&q, &squared_euclidean, p).unwrap()
+        .map_with(&tree, |t, q| {
+            t.nearest_one(&q, &squared_euclidean).unwrap()
         }).collect::<Vec<_>>();
 
     // Check vs brute force
@@ -508,7 +508,7 @@ fn test_periodic_2d_nearest() {
     let mut rng = rand::thread_rng();
 
     // Initialize KdTree
-    let mut tree = KdTree::with_per_node_capacity(32).unwrap();
+    let mut tree = KdTree::periodic_with_per_node_capacity(32, &PERIODIC).unwrap();
 
     // Initialize data points (aka point cloud)
     let mut data = vec![[0.0; K]; NDATA];
@@ -535,8 +535,8 @@ fn test_periodic_2d_nearest() {
     // Query points
     let knns: Vec<(f64, &usize)> = (&query)
         .into_par_iter()
-        .map_with((&tree, &PERIODIC), |(t, p), q| {
-            t.nearest_one_periodic(&q, &squared_euclidean, p).unwrap()
+        .map_with(&tree, |t, q| {
+            t.nearest_one(&q, &squared_euclidean).unwrap()
         }).collect::<Vec<_>>();
 
     // Check vs brute force
@@ -607,7 +607,7 @@ fn test_periodic_3d_nearest() {
     let mut rng = rand::thread_rng();
 
     // Initialize KdTree
-    let mut tree = KdTree::with_per_node_capacity(32).unwrap();
+    let mut tree = KdTree::periodic_with_per_node_capacity(32, &PERIODIC).unwrap();
 
     // Initialize data points (aka point cloud)
     let mut data = vec![[0.0; K]; NDATA];
@@ -634,8 +634,8 @@ fn test_periodic_3d_nearest() {
     // Query points
     let knns: Vec<(f64, &usize)> = (&query)
         .into_par_iter()
-        .map_with((&tree, &PERIODIC), |(t, p), q| {
-            t.nearest_one_periodic(&q, &squared_euclidean, p).unwrap()
+        .map_with(&tree, |t, q| {
+            t.nearest_one(&q, &squared_euclidean).unwrap()
         }).collect::<Vec<_>>();
 
     // Check vs brute force
@@ -711,7 +711,7 @@ fn test_periodic_1d_nearest_n() {
     let mut rng = rand::thread_rng();
 
     // Initialize KdTree
-    let mut tree = KdTree::with_per_node_capacity(32).unwrap();
+    let mut tree = KdTree::periodic_with_per_node_capacity(32, &PERIODIC).unwrap();
 
     // Initialize data points (aka point cloud)
     let mut data = vec![[0.0; K]; NDATA];
@@ -738,8 +738,8 @@ fn test_periodic_1d_nearest_n() {
     // Query points
     let knns: Vec<Vec<(f64, &usize)>> = (&query)
         .into_par_iter()
-        .map_with((&tree, &PERIODIC), |(t, p), q| {
-            t.nearest_periodic(&q, N, &squared_euclidean, p).unwrap()
+        .map_with(&tree, |t, q| {
+            t.nearest(&q, N, &squared_euclidean).unwrap()
         }).collect::<Vec<_>>();
 
     // Check vs brute force
@@ -816,7 +816,7 @@ fn test_periodic_2d_nearest_n() {
     let mut rng = rand::thread_rng();
 
     // Initialize KdTree
-    let mut tree = KdTree::with_per_node_capacity(32).unwrap();
+    let mut tree = KdTree::periodic_with_per_node_capacity(32, &PERIODIC).unwrap();
 
     // Initialize data points (aka point cloud)
     let mut data = vec![[0.0; K]; NDATA];
@@ -843,8 +843,8 @@ fn test_periodic_2d_nearest_n() {
     // Query points
     let knns: Vec<Vec<(f64, &usize)>> = (&query)
         .into_par_iter()
-        .map_with((&tree, &PERIODIC), |(t, p), q| {
-            t.nearest_periodic(&q, N, &squared_euclidean, p).unwrap()
+        .map_with(&tree, |t, q| {
+            t.nearest(&q, N, &squared_euclidean).unwrap()
         }).collect::<Vec<_>>();
 
     // Check vs brute force
@@ -921,7 +921,7 @@ fn test_periodic_3d_nearest_n() {
     let mut rng = rand::thread_rng();
 
     // Initialize KdTree
-    let mut tree = KdTree::with_per_node_capacity(32).unwrap();
+    let mut tree = KdTree::periodic_with_per_node_capacity(32, &PERIODIC).unwrap();
 
     // Initialize data points (aka point cloud)
     let mut data = vec![[0.0; K]; NDATA];
@@ -948,8 +948,8 @@ fn test_periodic_3d_nearest_n() {
     // Query points
     let knns: Vec<Vec<(f64, &usize)>> = (&query)
         .into_par_iter()
-        .map_with((&tree, &PERIODIC), |(t, p), q| {
-            t.nearest_periodic(&q, N, &squared_euclidean, p).unwrap()
+        .map_with(&tree, |t, q| {
+            t.nearest(&q, N, &squared_euclidean).unwrap()
         }).collect::<Vec<_>>();
 
     // Check vs brute force
@@ -1028,7 +1028,7 @@ fn test_periodic_1d_within() {
     let mut rng = rand::thread_rng();
 
     // Initialize KdTree
-    let mut tree = KdTree::with_per_node_capacity(32).unwrap();
+    let mut tree = KdTree::periodic_with_per_node_capacity(32, &PERIODIC).unwrap();
 
     // Initialize data points (aka point cloud)
     let mut data = vec![[0.0; K]; NDATA];
@@ -1055,8 +1055,8 @@ fn test_periodic_1d_within() {
     // Query points
     let knns: Vec<Vec<(f64, &usize)>> = (&query)
         .into_par_iter()
-        .map_with((&tree, &PERIODIC), |(t, p), q| {
-            t.within_periodic(&q, RADIUS, &squared_euclidean, p).unwrap()
+        .map_with(&tree, |t, q| {
+            t.within(&q, RADIUS, &squared_euclidean).unwrap()
         }).collect::<Vec<_>>();
 
     // Check vs brute force
@@ -1135,7 +1135,7 @@ fn test_periodic_2d_within() {
     let mut rng = rand::thread_rng();
 
     // Initialize KdTree
-    let mut tree = KdTree::with_per_node_capacity(32).unwrap();
+    let mut tree = KdTree::periodic_with_per_node_capacity(32, &PERIODIC).unwrap();
 
     // Initialize data points (aka point cloud)
     let mut data = vec![[0.0; K]; NDATA];
@@ -1162,8 +1162,8 @@ fn test_periodic_2d_within() {
     // Query points
     let knns: Vec<Vec<(f64, &usize)>> = (&query)
         .into_par_iter()
-        .map_with((&tree, &PERIODIC), |(t, p), q| {
-            t.within_periodic(&q, RADIUS, &squared_euclidean, p).unwrap()
+        .map_with(&tree, |t, q| {
+            t.within(&q, RADIUS, &squared_euclidean).unwrap()
         }).collect::<Vec<_>>();
 
     // Check vs brute force
@@ -1242,7 +1242,8 @@ fn test_periodic_3d_within() {
     let mut rng = rand::thread_rng();
 
     // Initialize KdTree
-    let mut tree = KdTree::with_per_node_capacity(32).unwrap();
+    println!("initializing tree");
+    let mut tree = KdTree::periodic_with_per_node_capacity(32, &PERIODIC).unwrap();
 
     // Initialize data points (aka point cloud)
     let mut data = vec![[0.0; K]; NDATA];
@@ -1269,8 +1270,8 @@ fn test_periodic_3d_within() {
     // Query points
     let knns: Vec<Vec<(f64, &usize)>> = (&query)
         .into_par_iter()
-        .map_with((&tree, &PERIODIC), |(t, p), q| {
-            t.within_periodic(&q, RADIUS, &squared_euclidean, p).unwrap()
+        .map_with(&tree, |t, q| {
+            t.within(&q, RADIUS, &squared_euclidean).unwrap()
         }).collect::<Vec<_>>();
 
     // Check vs brute force


### PR DESCRIPTION
This incorporates some of the feedback you gave me on the last attempt. I had made a mess of my branch so I'm here with a new one and a new PR. This one has a much cleaner API and also has some correctness tests with brute force checks. I would like to continue adding a few more functions e.g. `best_n_within`, but for now `nearest`, `nearest_one`, `within` and `within_unsorted` work with periodic boundary conditions.

I noticed that your `check_point` suffered from the same ill so I changed it to allow early returns
```rust
    fn check_point(&self, point: &[A; K]) -> Result<(), ErrorKind> {
        for p in point {
            if !p.is_finite(){
                return Err(ErrorKind::NonFiniteCoordinate)
            }
        }

        if let Some(periodic) = self.periodic {
            for (idx, &p) in point.iter().enumerate() {
                if p < A::zero() || p > periodic[idx] {
                    return Err(ErrorKind::OutOfPeriodicBounds)
                }
            }
        }
        Ok(())
    }
```

Also I didn't get to thinking about how to serialize the `Option`, which is now an `Option<&'a [A; K]>` so that we don't have an identical copy of the array at every `KdTree`.

I wrote a benchmark with 1m query points and 100k data points and timed building and querying and got (non-pbc/pbc)
```
average: 26/26 millis to build, 85/92 millis to query
```
running on 48 threads. I can include this bench if you'd like. The build time is expected to be exactly the same because in this implementation the build is the same. The PBCs are handled by checking if it is necessary to apply PBCs (e.g. if your 1NN distance > distance to edge of box) and doing additional queries with only those relevant images.