### PR TITLE
Periodic boundary conditions: updated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "as-slice"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,9 +256,10 @@ dependencies = [
 
 [[package]]
 name = "kiddo"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "aligned",
+ "approx",
  "criterion",
  "num-traits",
  "rand",
@@ -431,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -443,14 +453,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ criterion = "0.3.4"
 aligned = "0.4"
 serde = "1.0"
 serde_json = "1.0.64"
+rayon = "1.5.3"
 
 [dependencies]
 num-traits = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ edition = "2018"
 all-features = true
 
 [dev-dependencies]
+approx = "0.5.1"
 rand = "0.8"
 rand_distr = "0.4"
 criterion = "0.3.4"
 aligned = "0.4"
 serde = "1.0"
 serde_json = "1.0.64"
-rayon = "1.5.3"
 
 [dependencies]
 num-traits = "0.2"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@
 * [Benchmarks](#benchmarks)
 * [License](#license)
 
+## Features
+
+* Generic over number of dimensions, float type used as co-ordinates, and stored content type.
+* User-selectable distance metric.
+* Available query methods:
+  * Nearest one item
+  * Nearest n items (as vec or iterator)
+  * All items within specified distance (sorted and unsorted)
+  * "best" items within specified distance. "Best" is determined by the implementation of the comparison operators on the type of the stored items
+* [Periodic Boundary Conditions](https://en.wikipedia.org/wiki/Periodic_boundary_conditions) are supported. PBC-specific queries: 
+  * Nearest one item
+  * Nearest n items
+  * All items within specified distance (sorted and unsorted)
+  Thanks to [@cavemanloverboy](https://github.com/cavemanloverboy) for the PBC contribution
+
 
 ## Differences vs kdtree@0.6.0
 

--- a/src/kiddo.rs
+++ b/src/kiddo.rs
@@ -151,14 +151,15 @@ impl<'a, A: Float + Zero + One + Signed, T: std::cmp::PartialEq, const K: usize>
 
     /// Creates a new KdTree with a specific capacity **per node**. You may wish to
     /// experiment by tuning this value to best suit your workload via benchmarking:
-    /// values between 10 and 40 often work best.
+    /// values between 10 and 40 often work best. Obeys periodic boundary conditions.
     ///
     /// # Examples
     ///
     /// ```rust
     /// use kiddo::KdTree;
     ///
-    /// let mut tree: KdTree<f64, usize, 3> = KdTree::with_per_node_capacity(30)?;
+    /// const PERIODIC: [f64; 3] = [10.0, 10.0, 10.0];
+    /// let mut tree: KdTree<f64, usize, 3> = KdTree::periodic_with_per_node_capacity(30, &PERIODIC)?;
     ///
     /// tree.add(&[1.0, 2.0, 5.0], 100)?;
     /// # Ok::<(), kiddo::ErrorKind>(())

--- a/src/kiddo.rs
+++ b/src/kiddo.rs
@@ -1608,7 +1608,7 @@ impl std::error::Error for ErrorKind {}
 impl std::fmt::Display for ErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let reason = match *self {
-            ErrorKind::OutOfPeriodicBounds => "out of bounds while using periodic boundary conditions",
+            ErrorKind::OutOfPeriodicBounds => "point is out of bounds (periodic boundary conditions)",
             ErrorKind::NonFiniteCoordinate => "non-finite coordinate",
             ErrorKind::ZeroCapacity => "zero capacity",
             ErrorKind::Empty => "invalid operation on empty tree",

--- a/src/kiddo.rs
+++ b/src/kiddo.rs
@@ -125,13 +125,16 @@ impl<A: Float + Zero + One, T: PartialEq, const K: usize> KdTree<A, T, K> {
                 points: Vec::with_capacity(capacity),
                 bucket: Vec::with_capacity(capacity),
                 capacity,
-            }
+            },
         })
     }
 
     /// Creates a new KdTree with a specific capacity **per node**.
     ///
-    #[deprecated(since = "0.1.8", note = "with_capacity has a misleading name. Users should instead use with_per_node_capacity. with_capacity will be removed in a future release")]
+    #[deprecated(
+        since = "0.1.8",
+        note = "with_capacity has a misleading name. Users should instead use with_per_node_capacity. with_capacity will be removed in a future release"
+    )]
     pub fn with_capacity(capacity: usize) -> Result<Self, ErrorKind> {
         Self::with_per_node_capacity(capacity)
     }

--- a/src/kiddo.rs
+++ b/src/kiddo.rs
@@ -127,6 +127,56 @@ impl<'a, A: Float + Zero + One + Signed, T: std::cmp::PartialEq, const K: usize>
                 bucket: Vec::with_capacity(capacity),
                 capacity,
             },
+            periodic: None,
+        })
+    }
+
+    /// Creates a new KdTree with default capacity **per node** of 16.
+    /// Obeys periodic boundary conditions.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use kiddo::KdTree;
+    ///
+    /// let mut tree: KdTree<f64, usize, 3> = KdTree::new();
+    ///
+    /// tree.add(&[1.0, 2.0, 5.0], 100)?;
+    /// # Ok::<(), kiddo::ErrorKind>(())
+    /// ```
+    pub fn new_periodic(periodic: &'a [A; K]) -> Self {
+        KdTree::periodic_with_per_node_capacity(16, periodic).unwrap()
+    }
+
+    /// Creates a new KdTree with a specific capacity **per node**. You may wish to
+    /// experiment by tuning this value to best suit your workload via benchmarking:
+    /// values between 10 and 40 often work best.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use kiddo::KdTree;
+    ///
+    /// let mut tree: KdTree<f64, usize, 3> = KdTree::with_per_node_capacity(30)?;
+    ///
+    /// tree.add(&[1.0, 2.0, 5.0], 100)?;
+    /// # Ok::<(), kiddo::ErrorKind>(())
+    /// ```
+    pub fn periodic_with_per_node_capacity(capacity: usize, periodic: &'a [A; K]) -> Result<Self, ErrorKind> {
+        if capacity == 0 {
+            return Err(ErrorKind::ZeroCapacity);
+        }
+
+        Ok(KdTree {
+            size: 0,
+            min_bounds: [A::infinity(); K],
+            max_bounds: [A::neg_infinity(); K],
+            content: Node::Leaf {
+                points: Vec::with_capacity(capacity),
+                bucket: Vec::with_capacity(capacity),
+                capacity,
+            },
+            periodic: Some(periodic),
         })
     }
 

--- a/src/kiddo.rs
+++ b/src/kiddo.rs
@@ -1130,12 +1130,12 @@ impl<A: Float + Zero + One, T: PartialEq, const K: usize> KdTree<A, T, K> {
         }
     }
 
-    fn populate_pending<'b, F>(
+    fn populate_pending<'a, F>(
         point: &[A; K],
         max_dist: A,
         distance: &F,
-        pending: &mut impl Stack<HeapElement<A, &'b Self>>,
-        curr: &mut &'b Self,
+        pending: &mut impl Stack<HeapElement<A, &'a Self>>,
+        curr: &mut &'a Self,
     ) where
         F: Fn(&[A; K], &[A; K]) -> A,
     {
@@ -1186,11 +1186,11 @@ impl<A: Float + Zero + One, T: PartialEq, const K: usize> KdTree<A, T, K> {
     /// assert_eq!(*nearest_first.1, 100);
     /// # Ok::<(), kiddo::ErrorKind>(())
     /// ```
-    pub fn iter_nearest<'b, 'c, F>(
-        &'c self,
-        point: &'b [A; K],
-        distance: &'b F,
-    ) -> Result<NearestIter<'b, 'c, A, T, F, K>, ErrorKind>
+    pub fn iter_nearest<'a, 'b, F>(
+        &'b self,
+        point: &'a [A; K],
+        distance: &'a F,
+    ) -> Result<NearestIter<'a, 'b, A, T, F, K>, ErrorKind>
     where
         F: Fn(&[A; K], &[A; K]) -> A,
     {

--- a/tests/kdtree.rs
+++ b/tests/kdtree.rs
@@ -409,7 +409,7 @@ fn test_periodic_1d_nearest() {
     let mut rng = rand::thread_rng();
 
     // Initialize KdTree
-    let mut tree = KdTree::with_per_node_capacity(32).unwrap();
+    let mut tree = KdTree::periodic_with_per_node_capacity(32, &PERIODIC).unwrap();
 
     // Initialize data points (aka point cloud)
     let mut data = vec![[0.0; K]; NDATA];
@@ -436,8 +436,8 @@ fn test_periodic_1d_nearest() {
     // Query points
     let knns: Vec<(f64, &usize)> = (&query)
         .into_par_iter()
-        .map_with((&tree, &PERIODIC), |(t, p), q| {
-            t.nearest_one_periodic(&q, &squared_euclidean, p).unwrap()
+        .map_with(&tree, |t, q| {
+            t.nearest_one(&q, &squared_euclidean).unwrap()
         }).collect::<Vec<_>>();
 
     // Check vs brute force
@@ -508,7 +508,7 @@ fn test_periodic_2d_nearest() {
     let mut rng = rand::thread_rng();
 
     // Initialize KdTree
-    let mut tree = KdTree::with_per_node_capacity(32).unwrap();
+    let mut tree = KdTree::periodic_with_per_node_capacity(32, &PERIODIC).unwrap();
 
     // Initialize data points (aka point cloud)
     let mut data = vec![[0.0; K]; NDATA];
@@ -535,8 +535,8 @@ fn test_periodic_2d_nearest() {
     // Query points
     let knns: Vec<(f64, &usize)> = (&query)
         .into_par_iter()
-        .map_with((&tree, &PERIODIC), |(t, p), q| {
-            t.nearest_one_periodic(&q, &squared_euclidean, p).unwrap()
+        .map_with(&tree, |t, q| {
+            t.nearest_one(&q, &squared_euclidean).unwrap()
         }).collect::<Vec<_>>();
 
     // Check vs brute force
@@ -607,7 +607,7 @@ fn test_periodic_3d_nearest() {
     let mut rng = rand::thread_rng();
 
     // Initialize KdTree
-    let mut tree = KdTree::with_per_node_capacity(32).unwrap();
+    let mut tree = KdTree::periodic_with_per_node_capacity(32, &PERIODIC).unwrap();
 
     // Initialize data points (aka point cloud)
     let mut data = vec![[0.0; K]; NDATA];
@@ -634,8 +634,8 @@ fn test_periodic_3d_nearest() {
     // Query points
     let knns: Vec<(f64, &usize)> = (&query)
         .into_par_iter()
-        .map_with((&tree, &PERIODIC), |(t, p), q| {
-            t.nearest_one_periodic(&q, &squared_euclidean, p).unwrap()
+        .map_with(&tree, |t, q| {
+            t.nearest_one(&q, &squared_euclidean).unwrap()
         }).collect::<Vec<_>>();
 
     // Check vs brute force
@@ -711,7 +711,7 @@ fn test_periodic_1d_nearest_n() {
     let mut rng = rand::thread_rng();
 
     // Initialize KdTree
-    let mut tree = KdTree::with_per_node_capacity(32).unwrap();
+    let mut tree = KdTree::periodic_with_per_node_capacity(32, &PERIODIC).unwrap();
 
     // Initialize data points (aka point cloud)
     let mut data = vec![[0.0; K]; NDATA];
@@ -738,8 +738,8 @@ fn test_periodic_1d_nearest_n() {
     // Query points
     let knns: Vec<Vec<(f64, &usize)>> = (&query)
         .into_par_iter()
-        .map_with((&tree, &PERIODIC), |(t, p), q| {
-            t.nearest_periodic(&q, N, &squared_euclidean, p).unwrap()
+        .map_with(&tree, |t, q| {
+            t.nearest(&q, N, &squared_euclidean).unwrap()
         }).collect::<Vec<_>>();
 
     // Check vs brute force
@@ -816,7 +816,7 @@ fn test_periodic_2d_nearest_n() {
     let mut rng = rand::thread_rng();
 
     // Initialize KdTree
-    let mut tree = KdTree::with_per_node_capacity(32).unwrap();
+    let mut tree = KdTree::periodic_with_per_node_capacity(32, &PERIODIC).unwrap();
 
     // Initialize data points (aka point cloud)
     let mut data = vec![[0.0; K]; NDATA];
@@ -843,8 +843,8 @@ fn test_periodic_2d_nearest_n() {
     // Query points
     let knns: Vec<Vec<(f64, &usize)>> = (&query)
         .into_par_iter()
-        .map_with((&tree, &PERIODIC), |(t, p), q| {
-            t.nearest_periodic(&q, N, &squared_euclidean, p).unwrap()
+        .map_with(&tree, |t, q| {
+            t.nearest(&q, N, &squared_euclidean).unwrap()
         }).collect::<Vec<_>>();
 
     // Check vs brute force
@@ -921,7 +921,7 @@ fn test_periodic_3d_nearest_n() {
     let mut rng = rand::thread_rng();
 
     // Initialize KdTree
-    let mut tree = KdTree::with_per_node_capacity(32).unwrap();
+    let mut tree = KdTree::periodic_with_per_node_capacity(32, &PERIODIC).unwrap();
 
     // Initialize data points (aka point cloud)
     let mut data = vec![[0.0; K]; NDATA];
@@ -948,8 +948,8 @@ fn test_periodic_3d_nearest_n() {
     // Query points
     let knns: Vec<Vec<(f64, &usize)>> = (&query)
         .into_par_iter()
-        .map_with((&tree, &PERIODIC), |(t, p), q| {
-            t.nearest_periodic(&q, N, &squared_euclidean, p).unwrap()
+        .map_with(&tree, |t, q| {
+            t.nearest(&q, N, &squared_euclidean).unwrap()
         }).collect::<Vec<_>>();
 
     // Check vs brute force
@@ -1028,7 +1028,7 @@ fn test_periodic_1d_within() {
     let mut rng = rand::thread_rng();
 
     // Initialize KdTree
-    let mut tree = KdTree::with_per_node_capacity(32).unwrap();
+    let mut tree = KdTree::periodic_with_per_node_capacity(32, &PERIODIC).unwrap();
 
     // Initialize data points (aka point cloud)
     let mut data = vec![[0.0; K]; NDATA];
@@ -1055,8 +1055,8 @@ fn test_periodic_1d_within() {
     // Query points
     let knns: Vec<Vec<(f64, &usize)>> = (&query)
         .into_par_iter()
-        .map_with((&tree, &PERIODIC), |(t, p), q| {
-            t.within_periodic(&q, RADIUS, &squared_euclidean, p).unwrap()
+        .map_with(&tree, |t, q| {
+            t.within(&q, RADIUS, &squared_euclidean).unwrap()
         }).collect::<Vec<_>>();
 
     // Check vs brute force
@@ -1135,7 +1135,7 @@ fn test_periodic_2d_within() {
     let mut rng = rand::thread_rng();
 
     // Initialize KdTree
-    let mut tree = KdTree::with_per_node_capacity(32).unwrap();
+    let mut tree = KdTree::periodic_with_per_node_capacity(32, &PERIODIC).unwrap();
 
     // Initialize data points (aka point cloud)
     let mut data = vec![[0.0; K]; NDATA];
@@ -1162,8 +1162,8 @@ fn test_periodic_2d_within() {
     // Query points
     let knns: Vec<Vec<(f64, &usize)>> = (&query)
         .into_par_iter()
-        .map_with((&tree, &PERIODIC), |(t, p), q| {
-            t.within_periodic(&q, RADIUS, &squared_euclidean, p).unwrap()
+        .map_with(&tree, |t, q| {
+            t.within(&q, RADIUS, &squared_euclidean).unwrap()
         }).collect::<Vec<_>>();
 
     // Check vs brute force
@@ -1242,7 +1242,8 @@ fn test_periodic_3d_within() {
     let mut rng = rand::thread_rng();
 
     // Initialize KdTree
-    let mut tree = KdTree::with_per_node_capacity(32).unwrap();
+    println!("initializing tree");
+    let mut tree = KdTree::periodic_with_per_node_capacity(32, &PERIODIC).unwrap();
 
     // Initialize data points (aka point cloud)
     let mut data = vec![[0.0; K]; NDATA];
@@ -1269,8 +1270,8 @@ fn test_periodic_3d_within() {
     // Query points
     let knns: Vec<Vec<(f64, &usize)>> = (&query)
         .into_par_iter()
-        .map_with((&tree, &PERIODIC), |(t, p), q| {
-            t.within_periodic(&q, RADIUS, &squared_euclidean, p).unwrap()
+        .map_with(&tree, |t, q| {
+            t.within(&q, RADIUS, &squared_euclidean).unwrap()
         }).collect::<Vec<_>>();
 
     // Check vs brute force


### PR DESCRIPTION
* feat: PBC now expects the period as an argument when querying using PBC functions, rather than
  storing it in the tree. This prevents the memory layout of the KdTree struct
  from changing with the introduction of PBC, which would force existing users to have to
  rebuild any serialized trees if they wanted to upgrade.
* tests: PBC tests refactored to move common brute force PBC check code and
  data/query/tree generating into separate private function
* tests: PBC tests use neater float asserts from approx package
* tests: Rayon removed and PBC unit test query point and data point count reduced to
  improve unit test run time
* style: re-ran cargo fmt and cargo clippy and fixed clippy lints that were introduced